### PR TITLE
Save Presets

### DIFF
--- a/AssignmentPresets.lua
+++ b/AssignmentPresets.lua
@@ -56,8 +56,8 @@ function AssignmentPresetsUpdatePresets()
             nameFrame:SetText(presetName)
             nameFrame:SetHighlight(10, 145, 100)
             nameFrame:SetCallback("OnClick", function() LoadPreset(presetName) end)
-            presetFrames[presetName] = nameframe
-            presetGroup:AddChild(nameframe)
+            presetFrames[presetName] = nameFrame
+            presetGroup:AddChild(nameFrame)
          end
       end
    end

--- a/AssignmentPresets.lua
+++ b/AssignmentPresets.lua
@@ -1,42 +1,42 @@
---Contains functions to generate a container with accompanying set of buttons in a given frame
---to save the current state of the healer assignments and load them via onclick functions
+-- Contains functions to generate a container with accompanying set of buttons in a given frame
+-- to save the current state of the healer assignments and load them via onclick functions
 
 local AceGUI = LibStub("AceGUI-3.0")
 
---variables to store presets
+-- variables to store presets
 local presetList = {}
 local presetFrames = {}
 local presetStore = "Default"
 local presetEditBoxText = "Preset Name"
 
---Sets up the Save & Delete buttons as well as the preset container; loads components onto the frame
+-- Sets up the Save & Delete buttons as well as the preset container; loads components onto the frame
 function AssignmentPresetsSetupFrameContainers(frame)
-   --places preset container inside of main frame
+   -- places preset container inside of main frame
    presetMaster = AceGUI:Create("SimpleGroup")
    presetMaster:SetWidth(160)
    frame:AddChild(presetMaster)
 
-   --holds all of the preset frames
+   -- holds all of the preset frames
    presetGroup = AceGUI:Create("InlineGroup")
    presetGroup:SetRelativeWidth(1)
    presetGroup:SetTitle("Presets")
    presetMaster:AddChild(presetGroup)
 
-   --saves the state of all healer assignments
+   -- saves the state of all healer assignments
    local savestateButton = AceGUI:Create("Button")
    savestateButton:SetText("Save")
    savestateButton:SetRelativeWidth(1)
    savestateButton:SetCallback("OnClick", function () SaveState(presetStore) end)
    presetMaster:AddChild(savestateButton)
 
-   --deletes the currently selected preset
+   -- deletes the currently selected preset
    local deletestateButton = AceGUI:Create("Button")
    deletestateButton:SetText("Delete")
    deletestateButton:SetRelativeWidth(1)
    deletestateButton:SetCallback("OnClick", function() DeleteState(presetStore) end)
    presetMaster:AddChild(deletestateButton)
    
-   --text box to hold the preset name
+   -- text box to hold the preset name
    savestateNameBox = AceGUI:Create("EditBox")
    savestateNameBox:SetRelativeWidth(1)
    savestateNameBox:SetLabel("Preset Name")
@@ -45,77 +45,78 @@ function AssignmentPresetsSetupFrameContainers(frame)
    presetMaster:AddChild(savestateNameBox)
 end
 
---add preset names to container
+-- add preset names to container
 function AssignmentPresetsUpdatePresets()
-	if presetList ~= nil then
-		for presetName, assignments in pairs(presetList) do 
-			if presetFrames[presetName] == nil then
+   if presetList ~= nil then
+      for presetName, assignments in pairs(presetList) do 
+         if presetFrames[presetName] == nil then
                local nameframe = AceGUI:Create("InteractiveLabel")
                nameframe:SetRelativeWidth(1)
                nameframe:SetText(presetName)
-			   nameframe:SetHighlight(10, 145, 100)
-			   nameframe:SetCallback("OnClick", function() LoadState(presetName) end)
+            nameframe:SetHighlight(10, 145, 100)
+            nameframe:SetCallback("OnClick", function() LoadState(presetName) end)
                presetFrames[presetName] = nameframe
-			   presetGroup:AddChild(nameframe)
-			end
-		end
-	end
+            presetGroup:AddChild(nameframe)
+         end
+      end
+   end
 end
 
---called during CleanupFrames() in main
+-- called during CleanupFrames() in main
 function AssignmentPresetsCleanup()
-	presetFrames = {}
+   presetFrames = {}
 end
 
---Saves the current status of healers & their target
+-- Saves the current status of healers & their target
 function SaveState(name)
-	if debug then
-		print("\n-----------\nSAVESTATE")
-	end
+   if debug then
+      print("\n-----------\nSAVESTATE")
+   end
 
-	presetList[name] = {}
-	presetList[name] = CopyArray(assignedHealers)
+   presetEditBoxText = name
+   presetList[name] = {}
+   presetList[name] = CopyArray(assignedHealers)
 
-	CleanupFrame()
+   CleanupFrame()
     SetupFrameContainers()
     UpdateFrame()
 end
 
 --Loads the state saved under the preset list
 function LoadState(name)
-	if debug then
-		print("\n-----------\nLOADSTATE")
-	end
+   if debug then
+      print("\n-----------\nLOADSTATE")
+   end
 
-	presetEditBoxText = name
-	presetStore = name
-	assignedHealers = {}
-	assignedHealers = CopyArray(presetList[name])
-	CleanupFrame()
+   presetEditBoxText = name
+   presetStore = name
+   assignedHealers = {}
+   assignedHealers = CopyArray(presetList[name])
+   CleanupFrame()
     SetupFrameContainers()
     UpdateFrame()
 end
 
---will eventually need an option to delete presets
-function DeleteState(savename)
-	if debug then
-		print("\n-----------\nDELETESTATE")
-	end
-	presetList[savename] = nil
-	CleanupFrame()
-	SetupFrameContainers()
-	UpdateFrame()
+-- deletes the preset with the current name in the edit text box
+function DeleteState(name)
+   if debug then
+      print("\n-----------\nDELETESTATE")
+   end
+   presetList[name] = nil
+   CleanupFrame()
+   SetupFrameContainers()
+   UpdateFrame()
 end
 
 function CopyArray(array)
-	local copyTargets = {}
-	for target, healers in pairs(array) do
-		local copyHealers = {}
-		for i, players in ipairs(healers) do 
-			copyHealers[i] = players 
-		end
-		copyTargets[target] = copyHealers
-	end
+   local copyTargets = {}
+   for target, healers in pairs(array) do
+      local copyHealers = {}
+      for i, players in ipairs(healers) do 
+         copyHealers[i] = players 
+      end
+      copyTargets[target] = copyHealers
+   end
 
-	return copyTargets
+   return copyTargets
 end

--- a/AssignmentPresets.lua
+++ b/AssignmentPresets.lua
@@ -6,7 +6,7 @@ local AceGUI = LibStub("AceGUI-3.0")
 -- variables to store presets
 local presetList = {}
 local presetFrames = {}
-local presetStore = "Default"
+local selectedPreset = "Default"
 local presetEditBoxText = "Preset Name"
 
 -- Sets up the Save & Delete buttons as well as the preset container; loads components onto the frame
@@ -23,54 +23,57 @@ function AssignmentPresetsSetupFrameContainers(frame)
    presetMaster:AddChild(presetGroup)
 
    -- saves the state of all healer assignments
-   local savestateButton = AceGUI:Create("Button")
-   savestateButton:SetText("Save")
-   savestateButton:SetRelativeWidth(1)
-   savestateButton:SetCallback("OnClick", function () SaveState(presetStore) end)
-   presetMaster:AddChild(savestateButton)
+   local savePresetButton = AceGUI:Create("Button")
+   savePresetButton:SetText("Save")
+   savePresetButton:SetRelativeWidth(1)
+   savePresetButton:SetCallback("OnClick", function () SavePreset(selectedPreset) end)
+   presetMaster:AddChild(savePresetButton)
 
    -- deletes the currently selected preset
-   local deletestateButton = AceGUI:Create("Button")
-   deletestateButton:SetText("Delete")
-   deletestateButton:SetRelativeWidth(1)
-   deletestateButton:SetCallback("OnClick", function() DeleteState(presetStore) end)
-   presetMaster:AddChild(deletestateButton)
+   local deletePresetButton = AceGUI:Create("Button")
+   deletePresetButton:SetText("Delete")
+   deletePresetButton:SetRelativeWidth(1)
+   deletePresetButton:SetCallback("OnClick", function() DeletePreset(selectedPreset) end)
+   presetMaster:AddChild(deletePresetButton)
    
    -- text box to hold the preset name
-   savestateNameBox = AceGUI:Create("EditBox")
-   savestateNameBox:SetRelativeWidth(1)
-   savestateNameBox:SetLabel("Preset Name")
-   savestateNameBox:SetText(presetEditBoxText)
-   savestateNameBox:SetCallback("OnEnterPressed", function(widget, event, text) presetStore = text end)
-   presetMaster:AddChild(savestateNameBox)
+   presetNameBox = AceGUI:Create("EditBox")
+   presetNameBox:SetRelativeWidth(1)
+   presetNameBox:SetLabel("Preset Name")
+   presetNameBox:SetText(presetEditBoxText)
+   presetNameBox:SetCallback("OnEnterPressed", function(widget, event, text) selectedPreset = text end)
+   presetMaster:AddChild(presetNameBox)
 end
+
 
 -- add preset names to container
 function AssignmentPresetsUpdatePresets()
    if presetList ~= nil then
       for presetName, assignments in pairs(presetList) do 
          if presetFrames[presetName] == nil then
-               local nameframe = AceGUI:Create("InteractiveLabel")
-               nameframe:SetRelativeWidth(1)
-               nameframe:SetText(presetName)
-            nameframe:SetHighlight(10, 145, 100)
-            nameframe:SetCallback("OnClick", function() LoadState(presetName) end)
-               presetFrames[presetName] = nameframe
+            local nameFrame = AceGUI:Create("InteractiveLabel")
+            nameFrame:SetRelativeWidth(1)
+            nameFrame:SetText(presetName)
+            nameFrame:SetHighlight(10, 145, 100)
+            nameFrame:SetCallback("OnClick", function() LoadPreset(presetName) end)
+            presetFrames[presetName] = nameframe
             presetGroup:AddChild(nameframe)
          end
       end
    end
 end
 
+
 -- called during CleanupFrames() in main
 function AssignmentPresetsCleanup()
    presetFrames = {}
 end
 
+
 -- Saves the current status of healers & their target
-function SaveState(name)
+function SavePreset(name)
    if debug then
-      print("\n-----------\nSAVESTATE")
+      print("\n-----------\nSavePreset")
    end
 
    presetEditBoxText = name
@@ -78,35 +81,38 @@ function SaveState(name)
    presetList[name] = CopyArray(assignedHealers)
 
    CleanupFrame()
-    SetupFrameContainers()
-    UpdateFrame()
+   SetupFrameContainers()
+   UpdateFrame()
 end
 
---Loads the state saved under the preset list
-function LoadState(name)
+
+--  Loads the state saved under the preset list
+function LoadPreset(name)
    if debug then
-      print("\n-----------\nLOADSTATE")
+      print("\n-----------\nLoadPreset")
    end
 
    presetEditBoxText = name
-   presetStore = name
+   selectedPreset = name
    assignedHealers = {}
    assignedHealers = CopyArray(presetList[name])
    CleanupFrame()
-    SetupFrameContainers()
-    UpdateFrame()
+   SetupFrameContainers()
+   UpdateFrame()
 end
 
+
 -- deletes the preset with the current name in the edit text box
-function DeleteState(name)
+function DeletePreset(name)
    if debug then
-      print("\n-----------\nDELETESTATE")
+      print("\n-----------\nDeletePreset")
    end
    presetList[name] = nil
    CleanupFrame()
    SetupFrameContainers()
    UpdateFrame()
 end
+
 
 function CopyArray(array)
    local copyTargets = {}

--- a/AssignmentPresets.lua
+++ b/AssignmentPresets.lua
@@ -113,6 +113,7 @@ function DeletePreset(name)
    UpdateFrame()
 end
 
+
 -- TODO #14: make this generic and move into table.lua
 function CopyArray(array)
    local copyTargets = {}

--- a/AssignmentPresets.lua
+++ b/AssignmentPresets.lua
@@ -113,7 +113,7 @@ function DeletePreset(name)
    UpdateFrame()
 end
 
-
+-- TODO #14: make this generic and move into table.lua
 function CopyArray(array)
    local copyTargets = {}
    for target, healers in pairs(array) do

--- a/AssignmentPresets.lua
+++ b/AssignmentPresets.lua
@@ -1,0 +1,121 @@
+--Contains functions to generate a container with accompanying set of buttons in a given frame
+--to save the current state of the healer assignments and load them via onclick functions
+
+local AceGUI = LibStub("AceGUI-3.0")
+
+--variables to store presets
+local presetList = {}
+local presetFrames = {}
+local presetStore = "Default"
+local presetEditBoxText = "Preset Name"
+
+--Sets up the Save & Delete buttons as well as the preset container; loads components onto the frame
+function AssignmentPresetsSetupFrameContainers(frame)
+   --places preset container inside of main frame
+   presetMaster = AceGUI:Create("SimpleGroup")
+   presetMaster:SetWidth(160)
+   frame:AddChild(presetMaster)
+
+   --holds all of the preset frames
+   presetGroup = AceGUI:Create("InlineGroup")
+   presetGroup:SetRelativeWidth(1)
+   presetGroup:SetTitle("Presets")
+   presetMaster:AddChild(presetGroup)
+
+   --saves the state of all healer assignments
+   local savestateButton = AceGUI:Create("Button")
+   savestateButton:SetText("Save")
+   savestateButton:SetRelativeWidth(1)
+   savestateButton:SetCallback("OnClick", function () SaveState(presetStore) end)
+   presetMaster:AddChild(savestateButton)
+
+   --deletes the currently selected preset
+   local deletestateButton = AceGUI:Create("Button")
+   deletestateButton:SetText("Delete")
+   deletestateButton:SetRelativeWidth(1)
+   deletestateButton:SetCallback("OnClick", function() DeleteState(presetStore) end)
+   presetMaster:AddChild(deletestateButton)
+   
+   --text box to hold the preset name
+   savestateNameBox = AceGUI:Create("EditBox")
+   savestateNameBox:SetRelativeWidth(1)
+   savestateNameBox:SetLabel("Preset Name")
+   savestateNameBox:SetText(presetEditBoxText)
+   savestateNameBox:SetCallback("OnEnterPressed", function(widget, event, text) presetStore = text end)
+   presetMaster:AddChild(savestateNameBox)
+end
+
+--add preset names to container
+function AssignmentPresetsUpdatePresets()
+	if presetList ~= nil then
+		for presetName, assignments in pairs(presetList) do 
+			if presetFrames[presetName] == nil then
+               local nameframe = AceGUI:Create("InteractiveLabel")
+               nameframe:SetRelativeWidth(1)
+               nameframe:SetText(presetName)
+			   nameframe:SetHighlight(10, 145, 100)
+			   nameframe:SetCallback("OnClick", function() LoadState(presetName) end)
+               presetFrames[presetName] = nameframe
+			   presetGroup:AddChild(nameframe)
+			end
+		end
+	end
+end
+
+--called during CleanupFrames() in main
+function AssignmentPresetsCleanup()
+	presetFrames = {}
+end
+
+--Saves the current status of healers & their target
+function SaveState(name)
+	if debug then
+		print("\n-----------\nSAVESTATE")
+	end
+
+	presetList[name] = {}
+	presetList[name] = CopyArray(assignedHealers)
+
+	CleanupFrame()
+    SetupFrameContainers()
+    UpdateFrame()
+end
+
+--Loads the state saved under the preset list
+function LoadState(name)
+	if debug then
+		print("\n-----------\nLOADSTATE")
+	end
+
+	presetEditBoxText = name
+	presetStore = name
+	assignedHealers = {}
+	assignedHealers = CopyArray(presetList[name])
+	CleanupFrame()
+    SetupFrameContainers()
+    UpdateFrame()
+end
+
+--will eventually need an option to delete presets
+function DeleteState(savename)
+	if debug then
+		print("\n-----------\nDELETESTATE")
+	end
+	presetList[savename] = nil
+	CleanupFrame()
+	SetupFrameContainers()
+	UpdateFrame()
+end
+
+function CopyArray(array)
+	local copyTargets = {}
+	for target, healers in pairs(array) do
+		local copyHealers = {}
+		for i, players in ipairs(healers) do 
+			copyHealers[i] = players 
+		end
+		copyTargets[target] = copyHealers
+	end
+
+	return copyTargets
+end

--- a/AssignmentPresets.lua
+++ b/AssignmentPresets.lua
@@ -72,9 +72,7 @@ end
 
 -- Saves the current status of healers & their target
 function SavePreset(name)
-   if debug then
-      print("\n-----------\nSavePreset")
-   end
+   DebugPrint("\n-----------\nSavePreset")
 
    presetEditBoxText = name
    presetList[name] = {}
@@ -88,9 +86,7 @@ end
 
 --  Loads the state saved under the preset list
 function LoadPreset(name)
-   if debug then
-      print("\n-----------\nLoadPreset")
-   end
+   DebugPrint("\n-----------\nLoadPreset")
 
    presetEditBoxText = name
    selectedPreset = name
@@ -104,15 +100,12 @@ end
 
 -- deletes the preset with the current name in the edit text box
 function DeletePreset(name)
-   if debug then
-      print("\n-----------\nDeletePreset")
-   end
+   DebugPrint("\n-----------\nDeletePreset")
    presetList[name] = nil
    CleanupFrame()
    SetupFrameContainers()
    UpdateFrame()
 end
-
 
 -- TODO #14: make this generic and move into table.lua
 function CopyArray(array)

--- a/ClassicHealAssignments.lua
+++ b/ClassicHealAssignments.lua
@@ -6,13 +6,7 @@ local playerFrames = {}
 
 local assignmentGroups = {}
 
-local assignedHealers = {}
-
---variables to store presets
-local presetList = {}
-local presetFrames = {}
-local presetStore
-local presetEditBoxText = "Store your preset name here"
+assignedHealers = {}
 
 local classes = {}
 local roles = {}
@@ -37,7 +31,6 @@ function ClassicHealAssignments:OnEnable()
          mainWindow:Hide()
       end
 end
-
 
 function ClassicHealAssignments:OnDisable()
 end
@@ -125,23 +118,8 @@ function UpdateFrame()
       end
    end
 
-   --add preset names to container
-   print("preset list: " .. table.concat(presetList, ","))
-   if presetList ~= nil then
-		for presetName, assignments in pairs(presetList) do 
-			if presetFrames[presetName] == nil then
-				print("creating frame for preset...")
-               local nameframe = AceGUI:Create("InteractiveLabel")
-               nameframe:SetRelativeWidth(1)
-               nameframe:SetText(presetName)
-			   nameframe:SetColor(168, 159, 255)
-			   nameframe:SetHighlight(0.33, 10, 145, 100)
-			   nameframe:SetCallback("OnClick", function() LoadState(presetName, nameframe) end)
-               presetFrames[presetName] = nameframe
-			   presetGroup:AddChild(nameframe)
-			end
-		end
-	end
+
+   AssignmentPresetsUpdatePresets(assignedHealers)
 
    -- calling twice to avoid inconsistencies between re-renders
    mainWindow:DoLayout()
@@ -181,77 +159,6 @@ function CreateHealerDropdown(healers, assignment)
       end
    end
    return dropdown
-end
-
---dummy function which will later implement a save state feature
-function SaveState(savename)
-	if debug then
-		print("\n-----------\nSAVESTATE")
-	end
-
-	--CATCH IF SAVENAME IS NULL
-
-	print("saving preset list..." .. savename)
-
-	presetList[savename] = {}
-	local copyTargets = {}
-	for target, healers in pairs(assignedHealers) do
-		local copyHealers = {}
-		for i, players in ipairs(healers) do 
-			copyHealers[i] = players 
-		end
-		copyTargets[target] = copyHealers
-	end
-
-	presetList[savename] = copyTargets
-
-	for presetName, assignments in pairs(presetList) do
-		print("present name: " .. presetName)
-		if assignments[DISPELS] ~= nil then
-			print("First assignment: " .. table.concat(assignments[DISPELS], ","))
-		end
-	end
-
-	CleanupFrame()
-	SetupFrameContainers()
-	UpdateFrame()
-end
-
---dummy function which will later implement the load state feature. activated by clicking frames
-function LoadState(loadname, loadframe)
-	if debug then
-		print("\n-----------\nLOADSTATE")
-	end
-
-	presetEditBoxText = loadname
-	assignedHealers = {}
-	local copyTargets = {}
-	for target, healers in pairs(presetList[loadname]) do
-		local copyHealers = {}
-		for i, players in ipairs(healers) do 
-			copyHealers[i] = players 
-		end
-		copyTargets[target] = copyHealers
-	end
-
-	assignedHealers = copyTargets
-
-	for i, x in pairs(assignedHealers) do
-		print("Current assignments after loading: " .. i .. table.concat(x, ","))
-	end
-	CleanupFrame()
-	SetupFrameContainers()
-	UpdateFrame()
-end
-
---will eventually need an option to delete presets
-function DeleteState(savename)
-	if debug then
-		print("\n-----------\nDELETESTATE")
-	end
-	presetList[savename] = {}
-	CleanupFrame()
-	UpdateFrame()
 end
 
 function AnnounceHealers()
@@ -305,7 +212,7 @@ function CleanupFrame()
 
    assignmentGroups = {}
    playerFrames = {}
-   presetFrames = {}
+   AssignmentPresetsCleanup()
    mainWindow:ReleaseChildren()
 end
 
@@ -331,36 +238,13 @@ function SetupFrameContainers()
    assignmentWindow:SetLayout("Flow")
    mainWindow:AddChild(assignmentWindow)
 
-   --creates a basic window to test presets
-   presetGroup = AceGUI:Create("InlineGroup")
-   presetGroup:SetTitle("Presets")
-   presetGroup:SetWidth(80)
-   mainWindow:AddChild(presetGroup)
+   AssignmentPresetsSetupFrameContainers(mainWindow, assignedHealers)
 
    local announceButton = AceGUI:Create("Button")
    announceButton:SetText("Announce assignments")
    announceButton:SetCallback("OnClick", function() AnnounceHealers() end)
    mainWindow:AddChild(announceButton)
 
-   --button to save the state of all of the locations of the healers at the time
-   local savestateButton = AceGUI:Create("Button");
-   savestateButton:SetText("Save");
-   savestateButton:SetCallback("OnClick", function () SaveState(presetStore) end)
-   mainWindow:AddChild(savestateButton)
-
-   --creates the name for the save state
-    savestateNameBox = AceGUI:Create("EditBox");
-	savestateNameBox:SetWidth(200)
-	savestateNameBox:SetLabel("Preset Name")
-	savestateNameBox:SetText(presetEditBoxText)
-	savestateNameBox:SetCallback("OnEnterPressed", function(widget, event, text) presetStore = text end)
-	mainWindow:AddChild(savestateNameBox)
-
-	--deletes the currently selected preset
-	local deletestateButton = AceGUI:Create("Button")
-	deletestateButton:SetText("Delete Preset")
-	deletestateButton:SetCallback("OnClick", function() DeleteState(presetStore) end)
-	--mainWindow:AddChild(deletestateButton)
 end
 
 

--- a/ClassicHealAssignments.lua
+++ b/ClassicHealAssignments.lua
@@ -80,7 +80,6 @@ function UpdateFrame()
             if playerFrames[player] == nil then
                local nameFrame = AceGUI:Create("InteractiveLabel")
                nameFrame:SetRelativeWidth(1)
-               nameFrame:SetText(player)
                local classColors = healerColors[class]
                nameFrame:SetColor(classColors[1], classColors[2], classColors[3])
                playerFrames[player] = nameFrame

--- a/ClassicHealAssignments.lua
+++ b/ClassicHealAssignments.lua
@@ -8,6 +8,11 @@ local assignmentGroups = {}
 
 local assignedHealers = {}
 
+--variables to store presets, currently just for names
+local presetList = {}
+local presetFrames = {}
+local presetStore
+
 local classes = {}
 local roles = {}
 
@@ -65,6 +70,8 @@ function UpdateFrame()
    local dispellerList = {}
    local healerList = {}
 
+   local presetName --used to iterate through preset list
+
    classes, roles = GetRaidRoster()
 
    roles["DISPELS"] = {"DISPELS"}
@@ -117,6 +124,19 @@ function UpdateFrame()
       end
    end
 
+   --add preset names to container
+   if presetList ~= nil then
+		for i, presetName in ipairs(presetList) do 
+			if presetFrames[presetName] == nil then
+               local nameframe = AceGUI:Create("InteractiveLabel")
+               nameframe:SetRelativeWidth(1)
+               nameframe:SetText(presetName)
+               presetFrames[presetName] = nameframe
+			   presetGroup:AddChild(nameframe)
+			end
+		end
+	end
+
    -- calling twice to avoid inconsistencies between re-renders
    mainWindow:DoLayout()
    mainWindow:DoLayout()
@@ -156,6 +176,16 @@ function CreateHealerDropdown(healers, assignment)
    end
    return dropdown
 end
+
+--dummy function which will later implement a save state feature
+function SaveState()
+	if debug then
+		print("\n-----------\nSAVESTATE")
+	end
+	tinsert(presetList, presetStore)
+	UpdateFrame()
+end
+
 
 
 function AnnounceHealers()
@@ -242,28 +272,31 @@ function SetupFrameContainers()
    assignmentWindow:SetLayout("Flow")
    mainWindow:AddChild(assignmentWindow)
 
+   --creates a basic window to test presets
+   presetGroup = AceGUI:Create("InlineGroup")
+   presetGroup:SetTitle("Presets")
+   presetGroup:SetWidth(80)
+   mainWindow:AddChild(presetGroup)
+
    local announceButton = AceGUI:Create("Button")
    announceButton:SetText("Announce assignments")
    announceButton:SetCallback("OnClick", function() AnnounceHealers() end)
    mainWindow:AddChild(announceButton)
 
    --button to save the state of all of the locations of the healers at the time
-   --local savestateButton = AceGUI:Create("Button");
-   --savestateButton:setText("Save");
-   --savestateButton:SetCallback("OnClick", function ()( SaveState() end)
-   --mainWindow:AddChild(savestateButton)
+   local savestateButton = AceGUI:Create("Button");
+   savestateButton:SetText("Save");
+   savestateButton:SetCallback("OnClick", function () SaveState() end)
+   mainWindow:AddChild(savestateButton)
 
    --creates the name for the save state
-   --local presetStore
-   --local savestateNameBox = AceGUI:Create("EditBox");
-	--savestateNameBox:SetWidth(200)
-	--savestateNameBox:SetLabel("Preset Name")
-	--savestateNameBox:SetCallback("OnEnterPressed", function(widget, event, text) presetStore = text end)
-	--mainWindow:AddChild(savestateNameBox)
+   local savestateNameBox = AceGUI:Create("EditBox");
+	savestateNameBox:SetWidth(200)
+	savestateNameBox:SetLabel("Preset Name")
+	savestateNameBox:SetCallback("OnEnterPressed", function(widget, event, text) presetStore = text end)
+	mainWindow:AddChild(savestateNameBox)
 
 	--dropdown showing all of the frames
-end
-)
 end
 
 

--- a/ClassicHealAssignments.lua
+++ b/ClassicHealAssignments.lua
@@ -70,6 +70,7 @@ function UpdateFrame()
    roles["DISPELS"] = {"DISPELS"}
    roles["RAID"] = {"RAID"}
 
+
    for class, players in pairs(classes) do
       if healerColors[class] ~= nil then
          for _, player in ipairs(players) do
@@ -173,6 +174,14 @@ function AnnounceHealers()
    end
 end
 
+--saves the preset name and stores it in a container
+--later functionality to save the full preset of where all of the healers are
+--function SaveState() 
+	--if debug then
+		--print("\n-----------\nSAVESTATE")
+	--end
+--end
+
 
 function CreateAssignmentGroup(assignment, playerList)
    local nameframe = AceGUI:Create("InlineGroup")
@@ -237,6 +246,24 @@ function SetupFrameContainers()
    announceButton:SetText("Announce assignments")
    announceButton:SetCallback("OnClick", function() AnnounceHealers() end)
    mainWindow:AddChild(announceButton)
+
+   --button to save the state of all of the locations of the healers at the time
+   --local savestateButton = AceGUI:Create("Button");
+   --savestateButton:setText("Save");
+   --savestateButton:SetCallback("OnClick", function ()( SaveState() end)
+   --mainWindow:AddChild(savestateButton)
+
+   --creates the name for the save state
+   --local presetStore
+   --local savestateNameBox = AceGUI:Create("EditBox");
+	--savestateNameBox:SetWidth(200)
+	--savestateNameBox:SetLabel("Preset Name")
+	--savestateNameBox:SetCallback("OnEnterPressed", function(widget, event, text) presetStore = text end)
+	--mainWindow:AddChild(savestateNameBox)
+
+	--dropdown showing all of the frames
+end
+)
 end
 
 

--- a/ClassicHealAssignments.lua
+++ b/ClassicHealAssignments.lua
@@ -13,6 +13,8 @@ local presetList = {}
 local presetFrames = {}
 local presetStore
 
+local savestateNameBox = AceGUI:Create("EditBox"); --text box stored in global to be able to manipulate text value without passing 
+
 local classes = {}
 local roles = {}
 
@@ -131,6 +133,8 @@ function UpdateFrame()
                local nameframe = AceGUI:Create("InteractiveLabel")
                nameframe:SetRelativeWidth(1)
                nameframe:SetText(presetName)
+			   nameframe:SetColor(168, 159, 255)
+			   nameframe:SetCallback("OnClick", function() LoadState(presetName, nameframe) end)
                presetFrames[presetName] = nameframe
 			   presetGroup:AddChild(nameframe)
 			end
@@ -186,6 +190,16 @@ function SaveState()
 	UpdateFrame()
 end
 
+--dummy function which will later implement the load state feature. activated by clicking frames
+function LoadState(loadname, loadframe)
+	if debug then
+		print("\n-----------\nLOADSTATE")
+	end
+	savestateNameBox:SetText(loadname)
+	loadframe:SetHighlight(168, 159, 255)
+	loadframe:SetColor(168, 159, 255, 0.5)
+	UpdateFrame()
+end
 
 
 function AnnounceHealers()
@@ -290,7 +304,6 @@ function SetupFrameContainers()
    mainWindow:AddChild(savestateButton)
 
    --creates the name for the save state
-   local savestateNameBox = AceGUI:Create("EditBox");
 	savestateNameBox:SetWidth(200)
 	savestateNameBox:SetLabel("Preset Name")
 	savestateNameBox:SetCallback("OnEnterPressed", function(widget, event, text) presetStore = text end)

--- a/ClassicHealAssignments.lua
+++ b/ClassicHealAssignments.lua
@@ -71,25 +71,22 @@ function UpdateFrame()
    local dispellerList = {}
    local healerList = {}
 
-   local presetName --used to iterate through preset list
-
    classes, roles = GetRaidRoster()
 
    roles["DISPELS"] = {"DISPELS"}
    roles["RAID"] = {"RAID"}
 
-
    for class, players in pairs(classes) do
       if healerColors[class] ~= nil then
          for _, player in ipairs(players) do
             if playerFrames[player] == nil then
-               local nameframe = AceGUI:Create("InteractiveLabel")
-               nameframe:SetRelativeWidth(1)
-               nameframe:SetText(player)
+               local nameFrame = AceGUI:Create("InteractiveLabel")
+               nameFrame:SetRelativeWidth(1)
+               nameFrame:SetText(player)
                local classColors = healerColors[class]
-               nameframe:SetColor(classColors[1], classColors[2], classColors[3])
-               playerFrames[player] = nameframe
-               healerGroup:AddChild(nameframe)
+               nameFrame:SetColor(classColors[1], classColors[2], classColors[3])
+               playerFrames[player] = nameFrame
+               healerGroup:AddChild(nameFrame)
             end
             tinsert(healerList, player)
             tinsert(dispellerList, player)
@@ -126,7 +123,7 @@ function UpdateFrame()
    end
 
 
-   AssignmentPresetsUpdatePresets(assignedHealers)
+   AssignmentPresetsUpdatePresets()
 
    -- calling twice to avoid inconsistencies between re-renders
    mainWindow:DoLayout()

--- a/ClassicHealAssignments.lua
+++ b/ClassicHealAssignments.lua
@@ -182,13 +182,31 @@ function CreateHealerDropdown(healers, assignment)
 end
 
 --dummy function which will later implement a save state feature
-function SaveState()
+function SaveState(savename)
 	if debug then
 		print("\n-----------\nSAVESTATE")
 	end
+
+	--here should be a loop to go through the AssignedHealers list
+	--it will save all of the list to PresetList and add an additional column
+	--presetName attached to it.
+	presetList[savename] = assignedHealers
+
 	tinsert(presetList, presetStore)
+	Cleanupframe()
 	UpdateFrame()
 end
+
+--will eventually need an option to delete presets
+function DeleteState(savename)
+	if debug then
+		print("\n-----------\nDELETESTATE")
+	end
+	presetList[savename] = nil
+	Cleanupframe()
+	UpdateFrame()
+end
+
 
 --dummy function which will later implement the load state feature. activated by clicking frames
 function LoadState(loadname, loadframe)
@@ -198,6 +216,9 @@ function LoadState(loadname, loadframe)
 	savestateNameBox:SetText(loadname)
 	loadframe:SetHighlight(168, 159, 255)
 	loadframe:SetColor(168, 159, 255, 0.5)
+	assignedHealers = presetList[name]
+	CleanupFrame()
+	SetupFrameContainers()
 	UpdateFrame()
 end
 
@@ -300,7 +321,7 @@ function SetupFrameContainers()
    --button to save the state of all of the locations of the healers at the time
    local savestateButton = AceGUI:Create("Button");
    savestateButton:SetText("Save");
-   savestateButton:SetCallback("OnClick", function () SaveState() end)
+   savestateButton:SetCallback("OnClick", function () SaveState(presetStore) end)
    mainWindow:AddChild(savestateButton)
 
    --creates the name for the save state
@@ -309,7 +330,10 @@ function SetupFrameContainers()
 	savestateNameBox:SetCallback("OnEnterPressed", function(widget, event, text) presetStore = text end)
 	mainWindow:AddChild(savestateNameBox)
 
-	--dropdown showing all of the frames
+	--deletes the currently selected preset
+	local deletestateButton = AceGui:Create("Button")
+	deletestateButton:SetText("Delete Preset")
+	deletestateButton:SetCallback("OnClick", function() DeleteState(presetStore) end)
 end
 
 

--- a/ClassicHealAssignments.toc
+++ b/ClassicHealAssignments.toc
@@ -6,6 +6,6 @@
 embeds.xml
 
 ClassicHealAssignments.lua
-utils\table.lua
 AssignmentPresets.lua
+utils\table.lua
 utils\helpers.lua

--- a/ClassicHealAssignments.toc
+++ b/ClassicHealAssignments.toc
@@ -7,3 +7,4 @@ embeds.xml
 
 ClassicHealAssignments.lua
 utils\table.lua
+AssignmentPresets.lua


### PR DESCRIPTION
Added Preset Group container with ability to name, save, load and delete presets. Presets save the current healing assignments, allowing for multiple healing assignments to be created at one time. 

Closes #6 